### PR TITLE
Alle images bumpen & nach Github umziehen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,17 +3,16 @@ name: Build
 on:
   push:
     branches:
-      - '*'
-      - '*/*'
+      - 'main'
 env:
-  CI_TOOLS_VERSION: '^4.2.0'
+  CI_TOOLS_VERSION: '^5.0.0'
   # NOTE: Um den Releasezyklus von Alpha nach Beta zu ändern, einfach die nachfolgend deklarierten Env Variablen switchen.
   CI_TOOLS_ALPHA_BRANCH: next
   CI_TOOLS_ALPHA_NPM_TAG: next
-  CI_TOOLS_STABLE_BRANCH: main
   # CI_TOOLS_BETA_BRANCH: next
   # CI_TOOLS_BETA_NPM_TAG: next
-  #BOX_RELEASE_TAG: 2024-1
+  BOX_RELEASE_TAG: 2025-1
+
 jobs:
   build_version:
     runs-on: [ubuntu-latest]
@@ -38,9 +37,9 @@ jobs:
       - name: 'Prepare Version'
         if: "!startsWith(github.ref_name, 'renovate')"
         run: ci_tools prepare-version --allow-dirty-workdir
-            
+
       - name: Commit & Tag Version
-        run: | 
+        run: |
           ci_tools commit-and-tag-version --only-on-primary-branches
           ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag
         env:

--- a/base/artifactShipper/job.yaml
+++ b/base/artifactShipper/job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: artifactshipper
-          image: 5minds/processcube_artifact_shipper:1.0.0-renovate-cd1e08-m46rx4vj
+          image: ghcr.io/5minds/processcube_artifact_shipper:1.1.0
           imagePullPolicy: IfNotPresent
           env:
             - name: credentials__git__token

--- a/base/authority/deployment.yml
+++ b/base/authority/deployment.yml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: authority-container
-          image: 5minds/processcube_authority:3.1.2
+          image: ghcr.io/5minds/processcube__authority:3.1.2
           ports:
             - containerPort: 11560
           env:

--- a/base/engine/deployment.yml
+++ b/base/engine/deployment.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: engine-container
-          image: 5minds/engine:18.1.0-extensions-1.3.0
+          image: ghcr.io/5minds/processcube_engine:18.4.1-extensions-2.0.0
           ports:
             - containerPort: 10560
           env:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "processcube_deployment",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "Deployment Repository of ProcessCube"
 }


### PR DESCRIPTION
- Zieht alle Images in die GitHub Orga um
- Fixt das Image Prefix für das Engine Image
- Bumped alle Image Versionen auf die aktuellsten Stables

Breaking, da die Images private geworden sind und die Patch Configs entsprechend anders eingerichtet werden müssen.